### PR TITLE
exports a module instead of a global

### DIFF
--- a/locale-converter.js
+++ b/locale-converter.js
@@ -1,5 +1,4 @@
-var localeConverter = (function () {
-
+module.exports = function LocaleConverter () {
     var UNITS = {
         "CENTIARE":{
             name:"CENTIARE",
@@ -691,4 +690,4 @@ var ConversionRequest = function (params) {
         convert: convert,
         UNITS: UNITS
     }
-})();
+}


### PR DESCRIPTION
Hi @danikp!

This PR introduces two changes.
1. instead of exporting a global, the lib now exports a module.

It means that instead of having `localeConverter` magically available, you'll have to import it explicitly:
```js
import LocaleConverter from 'locale-converter'
```

So please wait until we upgrade our build system before merge,
or merge but update develop to use the current version.

2. The lib now exports a constructor instead of a singleton,
So, to use it, you'll have to initialize it first

```js
var localeConverter = new LocaleConverter();
```

That's it (: